### PR TITLE
Feature: Allow "fallback" option for consume-context helper

### DIFF
--- a/addon/-private/get-provider-for.js
+++ b/addon/-private/get-provider-for.js
@@ -3,13 +3,16 @@ import { LATEST_INSTANCE_MAP } from '../component-manager/context';
 
 const CONSUMER_TO_PROVIDER_MAP = new WeakMap();
 
-export function getProviderFor(object, key) {
+export function getProviderFor(object, key, fallback) {
   let provider;
 
   // Set up an object -> key -> provider relationship if it doesn't already exist
   if (!CONSUMER_TO_PROVIDER_MAP.get(object)?.get(key)) {
     provider = LATEST_INSTANCE_MAP.get(key);
-    assert(`A ContextProvider with key ${key} must be an ancestor`, provider);
+    assert(
+      `A ContextProvider with key ${key} must be an ancestor, or you must provide a fallback key`,
+      fallback || provider
+    );
 
     // Add a map for key -> provider for an object if we have not already
     if (!CONSUMER_TO_PROVIDER_MAP.has(object)) {

--- a/addon/helpers/consume-context.js
+++ b/addon/helpers/consume-context.js
@@ -5,6 +5,6 @@ export default class ContextConsumerHelper extends Helper {
   compute([key], { fallback }) {
     const provider = getProviderFor(this, key, fallback);
 
-    return (provider && provider.value) || fallback;
+    return provider ? provider.value : fallback;
   }
 }

--- a/addon/helpers/consume-context.js
+++ b/addon/helpers/consume-context.js
@@ -2,9 +2,9 @@ import Helper from '@ember/component/helper';
 import { getProviderFor } from '../-private/get-provider-for';
 
 export default class ContextConsumerHelper extends Helper {
-  compute([key]) {
-    const provider = getProviderFor(this, key);
+  compute([key], { fallback }) {
+    const provider = getProviderFor(this, key, fallback);
 
-    return provider.value;
+    return (provider && provider.value) || fallback;
   }
 }

--- a/addon/helpers/consume-context.js
+++ b/addon/helpers/consume-context.js
@@ -2,7 +2,8 @@ import Helper from '@ember/component/helper';
 import { getProviderFor } from '../-private/get-provider-for';
 
 export default class ContextConsumerHelper extends Helper {
-  compute([key], { fallback }) {
+  compute([key], opts) {
+    const fallback = opts ? opts.fallback : null;
     const provider = getProviderFor(this, key, fallback);
 
     return provider ? provider.value : fallback;

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,12 +1,12 @@
 import { getProviderFor } from './-private/get-provider-for';
 
-export function inject(key) {
+export function inject(key, { fallback }) {
   return function decorator() {
     return {
       get() {
-        const provider = getProviderFor(this, key);
+        const provider = getProviderFor(this, key, fallback);
 
-        return provider.value;
+        return provider ? provider.value : fallback;
       },
     };
   };

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,10 @@
 import { getProviderFor } from './-private/get-provider-for';
 
-export function inject(key, { fallback }) {
+export function inject(key, opts) {
   return function decorator() {
     return {
       get() {
+        const fallback = opts ? opts.fallback : null;
         const provider = getProviderFor(this, key, fallback);
 
         return provider ? provider.value : fallback;

--- a/tests/dummy/app/components/consume-key.js
+++ b/tests/dummy/app/components/consume-key.js
@@ -2,5 +2,5 @@ import Component from '@glimmer/component';
 import { inject as context } from '@alexlafroscia/ember-context';
 
 export default class ConsumeKeyComponent extends Component {
-  @context('key') value;
+  @context('key', { fallback: 'fallback-value' }) value;
 }

--- a/tests/integration/decorators/inject-test.js
+++ b/tests/integration/decorators/inject-test.js
@@ -23,6 +23,15 @@ module('Integration | Decorators | inject', function (hooks) {
     assert.dom().hasText('2', 'Consumer emits new value when Provider is updated');
   });
 
+  test('can inject a fallback value from a consumer', async function (assert) {
+    await render(hbs`
+      <ConsumeKey />
+    `);
+
+    // `fallback-value` is the fallback value set in the `consume-key` component for these tests
+    assert.dom().hasText('fallback-value', 'Consumer retrieved the value from the Provider');
+  });
+
   test('can handle adjacent instances of a provider with the same key', async function (assert) {
     this.set('first', 'a');
     this.set('second', 'b');

--- a/tests/integration/helpers/consume-context-test.js
+++ b/tests/integration/helpers/consume-context-test.js
@@ -78,4 +78,20 @@ module('Integration | Helpers | consume-context', function (hooks) {
     assert.dom('[data-test-first]').hasText('c', 'First instance reads new value');
     assert.dom('[data-test-second]').hasText('b', 'Second instance still reads original value');
   });
+
+  test('consumer returns fallback value when ContextProvider is not found', async function (assert) {
+    const fallbackValue = 'my-fallback';
+    this.set('fallbackValue', fallbackValue);
+
+    await render(hbs`
+      {{consume-context "key" fallback=fallbackValue}}
+    `);
+
+    assert
+      .dom()
+      .hasText(
+        fallbackValue,
+        'Consumer retrieved the fallback value from when Provider not present'
+      );
+  });
 });


### PR DESCRIPTION
This PR would update the usage of the `consume-context` helper to take a named "fallback" argument for the case where a parent ProviderContext is not found.

Example use:

```html
{{consume-context "shared-key" fallback="my-fallback-context-value"}}
```

The helper will first try to find the provider value for the "shared-key" context, and if not found it will return the fallback value.