### PR TITLE
fix: add main property to pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "doc": "doc",
     "test": "tests"
   },
+  "main": "index.js",
   "scripts": {
     "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",


### PR DESCRIPTION
Without it you cannot install the addon, you would get something like:

```
Error: Cannot find module '/Users/iradchenko/sandbox/ember-context-test/node_modules/heimdalljs/node_modules/rsvp/dist/rsvp.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:295:19)
    at Function.Module._findPath (internal/modules/cjs/loader.js:508:18)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:802:27)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/iradchenko/sandbox/ember-context-test/node_modules/heimdalljs/dist/heimdalljs.cjs.js:1:12)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/iradchenko/sandbox/ember-context-test/node_modules/heimdalljs/node_modules/rsvp/package.json',
  requestPath: 'rsvp'
}
```